### PR TITLE
Less strict constraints on C call arguments

### DIFF
--- a/src/Feldspar/Run/Frontend.hs
+++ b/src/Feldspar/Run/Frontend.hs
@@ -222,19 +222,19 @@ strArg :: String -> FunArg Data PrimType'
 strArg = Imp.strArg
 
 -- | Value argument
-valArg :: PrimType a => Data a -> FunArg Data PrimType'
+valArg :: PrimType' a => Data a -> FunArg Data PrimType'
 valArg = Imp.valArg
 
 -- | Reference argument
-refArg :: PrimType a => Ref a -> FunArg Data PrimType'
+refArg :: PrimType' a => Ref a -> FunArg Data PrimType'
 refArg (Ref r) = Imp.refArg (extractSingle r)
 
 -- | Mutable array argument
-arrArg :: PrimType a => Arr a -> FunArg Data PrimType'
+arrArg :: PrimType' a => Arr a -> FunArg Data PrimType'
 arrArg (Arr a) = Imp.arrArg (extractSingle a)
 
 -- | Immutable array argument
-iarrArg :: PrimType a => IArr a -> FunArg Data PrimType'
+iarrArg :: PrimType' a => IArr a -> FunArg Data PrimType'
 iarrArg (IArr a) = Imp.iarrArg (extractSingle a)
 
 -- | Abstract object argument


### PR DESCRIPTION
This is an interesting one. To be able to use these functions in my compiler in interpretation functions I needed to loose the constraints a little bit. Maybe there is another way to do it without this modification but currently I can't see how. (Actually I have an interpretation over `Run` that specifies `PrimType'` as `pred`, so I don't really have `PrimType` where it is needed by these argument converters.)